### PR TITLE
Remove incorrect JSON response builder

### DIFF
--- a/app/views/teachers/registrations/create.json.jbuilder
+++ b/app/views/teachers/registrations/create.json.jbuilder
@@ -1,3 +1,0 @@
-json.user do |json|
-  json.partial! "users/user", user: current_user
-end

--- a/app/views/teachers/sessions/create.json.jbuilder
+++ b/app/views/teachers/sessions/create.json.jbuilder
@@ -1,3 +1,0 @@
-json.user do |json|
-  json.partial! "users/user", user: current_user
-end


### PR DESCRIPTION
Hi @jerichson,

Apologies for the delay! This was tricky to pin down but there was a bug in the generated code. I've removed the issue so if you merge this change and re-deploy to Heroku you should be able to sign up and sign in with teachers the same way you do with students.

